### PR TITLE
feat: Create application for Kubernetes Pod validation via YAML

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/DmitryFedoroff/go-devops-engineer-magistr-lesson2-tpl
+
+go 1.22.8
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,3 +1,38 @@
 package main
 
-func main() {}
+import (
+	"fmt"
+	"os"
+
+	"github.com/DmitryFedoroff/go-devops-engineer-magistr-lesson2-tpl/yamlvalidator"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: yamlvalidator <filename>")
+		os.Exit(1)
+	}
+
+	filename := os.Args[1]
+
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		fmt.Printf("%s does not exist\n", filename)
+		os.Exit(1)
+	}
+
+	v, err := yamlvalidator.NewValidator(filename)
+	if err != nil {
+		fmt.Printf("Error initializing validator: %v\n", err)
+		os.Exit(1)
+	}
+
+	errors := v.Validate()
+	if len(errors) > 0 {
+		for _, err := range errors {
+			fmt.Println(err)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Println("YAML file is valid")
+}

--- a/yamlvalidator/constants.go
+++ b/yamlvalidator/constants.go
@@ -1,0 +1,21 @@
+package yamlvalidator
+
+import "regexp"
+
+const (
+	APIVersionExpected = "v1"
+	KindExpected       = "Pod"
+)
+
+var (
+	RegexSnakeCase    = regexp.MustCompile(`^[a-z]+(_[a-z]+)*$`)
+	RegexImage        = regexp.MustCompile(`^registry\.bigbrother\.io/(.+):(.+)$`)
+	RegexMemory       = regexp.MustCompile(`^(\d+)(Mi|Gi|Ki)$`)
+	RegexAbsolutePath = regexp.MustCompile(`^/.*`)
+
+	SupportedOSNames   = []string{"linux", "windows"}
+	SupportedProtocols = []string{"TCP", "UDP"}
+
+	PortNumberMin = 1
+	PortNumberMax = 65535
+)

--- a/yamlvalidator/core.go
+++ b/yamlvalidator/core.go
@@ -1,0 +1,543 @@
+package yamlvalidator
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+type Validator struct {
+	FilePath       string
+	RootNode       yaml.Node
+	ErrorCollector ErrorCollector
+}
+
+func NewValidator(filePath string) (*Validator, error) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get absolute path: %w", err)
+	}
+
+	content, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read file content: %w", err)
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(content, &root); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal file content: %w", err)
+	}
+
+	parentDir := filepath.Dir(absPath)
+	relPath, _ := filepath.Rel(parentDir, absPath)
+
+	return &Validator{
+		FilePath:       relPath,
+		RootNode:       root,
+		ErrorCollector: ErrorCollector{},
+	}, nil
+}
+
+func (v *Validator) Validate() []error {
+	for _, doc := range v.RootNode.Content {
+		v.validatePod(doc)
+	}
+	return v.ErrorCollector.Errors
+}
+
+func (v *Validator) validatePod(node *yaml.Node) {
+	requiredFields := []string{"apiVersion", "kind", "metadata", "spec"}
+	visitedFields := make(map[string]bool)
+
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		key := keyNode.Value
+		visitedFields[key] = true
+
+		switch key {
+		case "apiVersion":
+			v.validateAPIVersion(valueNode)
+		case "kind":
+			v.validateKind(valueNode)
+		case "metadata":
+			v.validateMetadata(valueNode)
+		case "spec":
+			v.validateSpec(valueNode)
+		}
+	}
+
+	for _, field := range requiredFields {
+		if !visitedFields[field] {
+			v.ErrorCollector.Add(&ValidationError{
+				FilePath: v.FilePath,
+				Line:     node.Line,
+				Message:  fmt.Sprintf("%s is required", field),
+			})
+		}
+	}
+}
+
+func (v *Validator) validateAPIVersion(node *yaml.Node) {
+	if node.Kind != yaml.ScalarNode || node.Value != APIVersionExpected {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("apiVersion has unsupported value '%s'", node.Value),
+		})
+	}
+}
+
+func (v *Validator) validateKind(node *yaml.Node) {
+	if node.Kind != yaml.ScalarNode || node.Value != KindExpected {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("kind has unsupported value '%s'", node.Value),
+		})
+	}
+}
+
+func (v *Validator) validateMetadata(node *yaml.Node) {
+	requiredFields := []string{"name"}
+	visitedFields := make(map[string]bool)
+
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		key := keyNode.Value
+		visitedFields[key] = true
+
+		switch key {
+		case "name":
+			v.validateName(valueNode, false)
+		case "labels":
+			v.validateLabels(valueNode)
+		}
+	}
+
+	for _, field := range requiredFields {
+		if !visitedFields[field] {
+			v.ErrorCollector.Add(&ValidationError{
+				FilePath: v.FilePath,
+				Line:     node.Line,
+				Message:  fmt.Sprintf("%s is required", field),
+			})
+		}
+	}
+}
+
+func (v *Validator) validateSpec(node *yaml.Node) {
+	requiredFields := []string{"containers"}
+	visitedFields := make(map[string]bool)
+
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		key := keyNode.Value
+		visitedFields[key] = true
+
+		switch key {
+		case "os":
+			v.validateOS(valueNode)
+		case "containers":
+			v.validateContainers(valueNode)
+		}
+	}
+
+	for _, field := range requiredFields {
+		if !visitedFields[field] {
+			v.ErrorCollector.Add(&ValidationError{
+				FilePath: v.FilePath,
+				Line:     node.Line,
+				Message:  fmt.Sprintf("%s is required", field),
+			})
+		}
+	}
+}
+
+func (v *Validator) validateOS(node *yaml.Node) {
+	if node.Kind != yaml.ScalarNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "os must be string",
+		})
+		return
+	}
+
+	if !ContainsString(node.Value, SupportedOSNames) {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("os has unsupported value '%s'", node.Value),
+		})
+	}
+}
+
+func (v *Validator) validateContainers(node *yaml.Node) {
+	if node.Kind != yaml.SequenceNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "containers must be an array",
+		})
+		return
+	}
+
+	for _, containerNode := range node.Content {
+		v.validateContainer(containerNode)
+	}
+}
+
+func (v *Validator) validateContainer(node *yaml.Node) {
+	requiredFields := []string{"name", "image", "resources"}
+	visitedFields := make(map[string]bool)
+
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		key := keyNode.Value
+		visitedFields[key] = true
+
+		switch key {
+		case "name":
+			v.validateName(valueNode, true)
+		case "image":
+			v.validateImage(valueNode)
+		case "ports":
+			v.validatePorts(valueNode)
+		case "readinessProbe":
+			v.validateProbe(valueNode)
+		case "livenessProbe":
+			v.validateProbe(valueNode)
+		case "resources":
+			v.validateResources(valueNode)
+		}
+	}
+
+	for _, field := range requiredFields {
+		if !visitedFields[field] {
+			v.ErrorCollector.Add(&ValidationError{
+				FilePath: v.FilePath,
+				Line:     node.Line,
+				Message:  fmt.Sprintf("%s is required", field),
+			})
+		}
+	}
+}
+
+func (v *Validator) validateName(node *yaml.Node, checkSnakeCase bool) {
+	if node.Kind != yaml.ScalarNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "name must be string",
+		})
+		return
+	}
+
+	if node.Value == "" {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "name is required",
+		})
+		return
+	}
+
+	if checkSnakeCase && !RegexSnakeCase.MatchString(node.Value) {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("name has invalid format '%s'", node.Value),
+		})
+	}
+}
+
+func (v *Validator) validateImage(node *yaml.Node) {
+	if node.Kind != yaml.ScalarNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "image must be string",
+		})
+		return
+	}
+
+	if !RegexImage.MatchString(node.Value) {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("image has invalid format '%s'", node.Value),
+		})
+	}
+}
+
+func (v *Validator) validatePorts(node *yaml.Node) {
+	if node.Kind != yaml.SequenceNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "ports must be an array",
+		})
+		return
+	}
+
+	for _, portNode := range node.Content {
+		v.validatePort(portNode)
+	}
+}
+
+func (v *Validator) validatePort(node *yaml.Node) {
+	requiredFields := []string{"containerPort"}
+	visitedFields := make(map[string]bool)
+
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		key := keyNode.Value
+		visitedFields[key] = true
+
+		switch key {
+		case "containerPort":
+			v.validatePortNumber(valueNode, "containerPort")
+		case "protocol":
+			v.validateProtocol(valueNode)
+		}
+	}
+
+	for _, field := range requiredFields {
+		if !visitedFields[field] {
+			v.ErrorCollector.Add(&ValidationError{
+				FilePath: v.FilePath,
+				Line:     node.Line,
+				Message:  fmt.Sprintf("%s is required", field),
+			})
+		}
+	}
+}
+
+func (v *Validator) validatePortNumber(node *yaml.Node, fieldName string) {
+	if node.Kind != yaml.ScalarNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("%s must be int", fieldName),
+		})
+		return
+	}
+
+	port, err := strconv.Atoi(node.Value)
+	if err != nil {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("%s must be int", fieldName),
+		})
+		return
+	}
+
+	if port < PortNumberMin || port > PortNumberMax {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("%s value out of range", fieldName),
+		})
+	}
+}
+
+func (v *Validator) validateProtocol(node *yaml.Node) {
+	if node.Kind != yaml.ScalarNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "protocol must be string",
+		})
+		return
+	}
+
+	if !ContainsString(node.Value, SupportedProtocols) {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("protocol has unsupported value '%s'", node.Value),
+		})
+	}
+}
+
+func (v *Validator) validateProbe(node *yaml.Node) {
+	requiredFields := []string{"httpGet"}
+	visitedFields := make(map[string]bool)
+
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		key := keyNode.Value
+		visitedFields[key] = true
+
+		if key == "httpGet" {
+			v.validateHTTPGet(valueNode)
+		}
+	}
+
+	for _, field := range requiredFields {
+		if !visitedFields[field] {
+			v.ErrorCollector.Add(&ValidationError{
+				FilePath: v.FilePath,
+				Line:     node.Line,
+				Message:  fmt.Sprintf("%s is required", field),
+			})
+		}
+	}
+}
+
+func (v *Validator) validateHTTPGet(node *yaml.Node) {
+	requiredFields := []string{"path", "port"}
+	visitedFields := make(map[string]bool)
+
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		key := keyNode.Value
+		visitedFields[key] = true
+
+		switch key {
+		case "path":
+			v.validateHTTPPath(valueNode)
+		case "port":
+			v.validatePortNumber(valueNode, "port")
+		}
+	}
+
+	for _, field := range requiredFields {
+		if !visitedFields[field] {
+			v.ErrorCollector.Add(&ValidationError{
+				FilePath: v.FilePath,
+				Line:     node.Line,
+				Message:  fmt.Sprintf("%s is required", field),
+			})
+		}
+	}
+}
+
+func (v *Validator) validateHTTPPath(node *yaml.Node) {
+	if node.Kind != yaml.ScalarNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "path must be string",
+		})
+		return
+	}
+
+	if !RegexAbsolutePath.MatchString(node.Value) {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("path has invalid format '%s'", node.Value),
+		})
+	}
+}
+
+func (v *Validator) validateResources(node *yaml.Node) {
+	for i := 0; i < len(node.Content); i += 2 {
+		_, valueNode := node.Content[i], node.Content[i+1]
+		v.validateResourceRequirements(valueNode)
+	}
+}
+
+func (v *Validator) validateResourceRequirements(node *yaml.Node) {
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode, valueNode := node.Content[i], node.Content[i+1]
+		key := keyNode.Value
+
+		switch key {
+		case "cpu":
+			v.validateCPU(valueNode)
+		case "memory":
+			v.validateMemory(valueNode)
+		}
+	}
+}
+
+func (v *Validator) validateCPU(node *yaml.Node) {
+	if node.Kind != yaml.ScalarNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "cpu must be int",
+		})
+		return
+	}
+
+	cpu, err := strconv.Atoi(node.Value)
+	if err != nil || cpu < 1 {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "cpu value out of range",
+		})
+	}
+}
+
+func (v *Validator) validateMemory(node *yaml.Node) {
+	if node.Kind != yaml.ScalarNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "memory must be string",
+		})
+		return
+	}
+
+	matches := RegexMemory.FindStringSubmatch(node.Value)
+	if matches == nil {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  fmt.Sprintf("memory has invalid format '%s'", node.Value),
+		})
+		return
+	}
+
+	amount, err := strconv.Atoi(matches[1])
+	if err != nil || amount < 1 {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "memory value out of range",
+		})
+	}
+}
+
+func (v *Validator) validateLabels(node *yaml.Node) {
+	if node.Kind != yaml.MappingNode {
+		v.ErrorCollector.Add(&ValidationError{
+			FilePath: v.FilePath,
+			Line:     node.Line,
+			Message:  "labels must be a mapping",
+		})
+		return
+	}
+
+	for i := 0; i < len(node.Content); i += 2 {
+		_, valueNode := node.Content[i], node.Content[i+1]
+		if valueNode.Kind != yaml.ScalarNode {
+			v.ErrorCollector.Add(&ValidationError{
+				FilePath: v.FilePath,
+				Line:     valueNode.Line,
+				Message:  "label value must be string",
+			})
+		}
+	}
+}

--- a/yamlvalidator/errorhandler.go
+++ b/yamlvalidator/errorhandler.go
@@ -1,0 +1,25 @@
+package yamlvalidator
+
+import "fmt"
+
+type ValidationError struct {
+	FilePath string
+	Line     int
+	Message  string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("%s:%d %s", e.FilePath, e.Line, e.Message)
+}
+
+type ErrorCollector struct {
+	Errors []error
+}
+
+func (ec *ErrorCollector) Add(err error) {
+	ec.Errors = append(ec.Errors, err)
+}
+
+func (ec *ErrorCollector) HasErrors() bool {
+	return len(ec.Errors) > 0
+}

--- a/yamlvalidator/utils.go
+++ b/yamlvalidator/utils.go
@@ -1,0 +1,10 @@
+package yamlvalidator
+
+func ContainsString(s string, list []string) bool {
+	for _, item := range list {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
#comment Create the initial version of the application that validates Kubernetes Pod specifications in YAML format:

1. Implement main logic for reading command-line arguments, checking file existence, and invoking validation.
2. Develop core validation logic for YAML files, including checking fields like apiVersion, kind, metadata, and spec.
3. Validate Kubernetes Pod container configurations, including resources (CPU, memory), ports, probes, and container readiness/liveness checks.
4. Implement error handling to collect and display validation errors, including file path and line number for each error.
5. Manage regular expressions for validating image names, memory formats, and other string patterns used in the YAML.
6. Create helper utilities like checking string presence in lists to aid with validation logic.
7. Ensure proper validation of resource requirements, such as CPU and memory, for containers in the Kubernetes Pod.
8. Enable multi-document YAML file validation for broader applicability.

Affected: main.go, constants.go, core.go, errorhandler.go, utils.go, go.mod, go.sum